### PR TITLE
Install into /usr instead of /usr/local

### DIFF
--- a/arctis-manager.spec
+++ b/arctis-manager.spec
@@ -12,8 +12,8 @@ hiddenimports += collect_submodules('arctis_manager.devices')
 
 python_ver_p = subprocess.run('python --version', shell=True, check=True, stdout=subprocess.PIPE)
 python_ver = '.'.join(python_ver_p.stdout.decode('utf-8').replace('Python ', '').split('.')[0:2])
-which_python_p = subprocess.run('which python', shell=True, check=True, stdout=subprocess.PIPE)
-pyqt6_path = Path(which_python_p.stdout.decode('utf-8')).parent.parent.joinpath('lib64', f'python{python_ver}', 'site-packages', 'PyQt6', 'Qt6')
+site_packages_p = subprocess.run('python3 -c "import sysconfig; print(sysconfig.get_path(\'purelib\'))"', shell=True, check=True, stdout=subprocess.PIPE)
+pyqt6_path = Path(site_packages_p.stdout.decode('utf-8')).parent.parent.parent.joinpath('lib64', f'python{python_ver}', 'site-packages', 'PyQt6', 'Qt6')
 
 print(str(pyqt6_path))
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z "${PREFIX}" ]; then
-    install_prefix=/usr/local
+    install_prefix=/usr
 else
     install_prefix=${PREFIX}
 fi

--- a/package_managers/ArctisManager.spec
+++ b/package_managers/ArctisManager.spec
@@ -35,15 +35,15 @@ mkdir -p %{buildroot}
 
 # execute the install script (with chroot feature)
 export CHROOT=%{buildroot}
-export PREFIX="/usr/local"
+export PREFIX="/usr"
 bash install.sh
 
 %files
 /usr/lib/udev/rules.d/91-steelseries-arctis.rules
 /usr/lib/systemd/user/arctis-manager.service
-/usr/local/bin/arctis-manager
-/usr/local/bin/arctis-manager-launcher
-/usr/local/share/applications/ArctisManager.desktop
+/usr/bin/arctis-manager
+/usr/bin/arctis-manager-launcher
+/usr/share/applications/ArctisManager.desktop
 /usr/share/icons/hicolor/scalable/apps/arctis_manager.svg
 
 %changelog


### PR DESCRIPTION
These are the changes I needed to make things work as mentioned in #19, other than the prefix changes I ran into a really weird issue where during the invocation of `pyinstaller` the `which` command could not be found, so I did a quick hack to keep everything working.

I tested the output and `rpm-ostree` installs it fine, though as mentioned in the issue I haven't been able to test the functionality yet.

```
+ python -m pipenv run pyinstaller arctis-manager.spec
42 INFO: PyInstaller: 6.12.0, contrib hooks: 2025.1
42 INFO: Python: 3.13.3
43 INFO: Platform: Linux-6.14.2-x86_64-with-glibc2.40
43 INFO: Python environment: /home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi
/bin/sh: line 1: which: command not found
Traceback (most recent call last):
    File "/home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi/bin/pyinstaller", line 8, in <module>
    sys.exit(_console_script_run())
    ~~~~~~~~~~~~~~~~~~~^^
    File "/home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi/lib/python3.13/site-packages/PyInstaller/__main__.py", line 231, in _console_script_run
    run()
    ~~~^^
    File "/home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi/lib/python3.13/site-packages/PyInstaller/__main__.py", line 215, in run
    run_build(pyi_config, spec_file, **vars(args))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi/lib/python3.13/site-packages/PyInstaller/__main__.py", line 70, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi/lib/python3.13/site-packages/PyInstaller/building/build_main.py", line 1270, in main
    build(specfile, distpath, workpath, clean_build)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/build/.local/share/virtualenvs/arctis-manager-1.17-build-9po78Wpi/lib/python3.13/site-packages/PyInstaller/building/build_main.py", line 1208, in build
    exec(code, spec_namespace)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^
    File "arctis-manager.spec", line 15, in <module>
    which_python_p = subprocess.run('which python3', shell=True, check=True, stdout=subprocess.PIPE)
    File "/usr/lib64/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
            output=stdout, stderr=stderr)
    subprocess.CalledProcessError: Command 'which python3' returned non-zero exit status 127.
```