### PR TITLE
Systemd: correct directives and .device target

### DIFF
--- a/systemd/arctis-manager.service
+++ b/systemd/arctis-manager.service
@@ -1,20 +1,15 @@
 [Unit]
 Description=Arctis Manager
-
-Requisite=dev-steelseries-arctis.device
-After=dev-steelseries-arctis.device
-
-StartLimitIntervalSec=1m
+Requires=dev-steelseries-arctis.device graphical-session.target
+After=dev-steelseries-arctis.device graphical-session.target
+StartLimitInterval=1min
 StartLimitBurst=5
 
 [Service]
-Type=exec
+Type=simple
 ExecStart=arctis-manager
 Restart=on-failure
 RestartSec=1
 
 [Install]
-WantedBy=dev-steelseries-arctis.device
 WantedBy=graphical-session.target
-Requisite=graphical-session.target
-After=graphical-session.target


### PR DESCRIPTION
This pull request fixes issues in the `arctis-manager.service` systemd unit file that were causing startup problems and race conditions with `xdg-desktop-portal.service`, and possibily other services.

- Replaces invalid directives like `Requisite=` and `Type=exec`
- Ensures proper dependency handling with `graphical-session.target`
- Fixes the use of multiple `WantedBy` entries