### PR TITLE
Fix pyqt6 path elegos/Linux-Arctis-Manager#16

### DIFF
--- a/arctis-manager.spec
+++ b/arctis-manager.spec
@@ -13,7 +13,7 @@ hiddenimports += collect_submodules('arctis_manager.devices')
 python_ver_p = subprocess.run('python --version', shell=True, check=True, stdout=subprocess.PIPE)
 python_ver = '.'.join(python_ver_p.stdout.decode('utf-8').replace('Python ', '').split('.')[0:2])
 which_python_p = subprocess.run('which python', shell=True, check=True, stdout=subprocess.PIPE)
-pyqt6_path = Path(which_python_p.stdout.decode('utf-8')).parent.parent.joinpath('lib64', f'python{python_ver}', 'site-packages', 'PyQt6', 'Qt6')
+pyqt6_path = Path(which_python_p.stdout.decode('utf-8')).parent.parent.joinpath('lib', f'python{python_ver}', 'site-packages', 'PyQt6', 'Qt6')
 
 print(str(pyqt6_path))
 


### PR DESCRIPTION
This fixed my broken build where I had the same error as #16.

Noticed that lib64 directory did not exist in the python virtualenv.